### PR TITLE
Complete pt_br localization

### DIFF
--- a/common/src/main/resources/assets/runes/lang/pt_br.json
+++ b/common/src/main/resources/assets/runes/lang/pt_br.json
@@ -1,7 +1,11 @@
 {
-  "gui.runes.rune_crafting" : "Criação de runas",
+  "gui.runes.rune_crafting": "Criação de runas",
   "block.runes.crafting_altar": "Altar de criação de runas",
   "block.runes.crafting_altar.hint": "Crie runas de forma mais econômica.",
+  "item.runes.small_rune_pouch": "Bolsa de Runas",
+  "item.runes.medium_rune_pouch": "Bolsa de Runas Fantasma",
+  "item.runes.large_rune_pouch": "Bolsa de Runas Mística",
+  "item.runes.rune_pouch.hint": "Fornece runas para o lançamento de feitiços quando equipada.",
   "item.runes.arcane_stone": "Runa arcana",
   "item.runes.fire_stone": "Runa de fogo",
   "item.runes.frost_stone": "Runa de gelo",


### PR DESCRIPTION
Completes the Brazilian Portuguese translation for Runes (was 9/13, now 13/13).

The four missing keys are the three rune pouches (Rune Pouch, Phantom Rune Pouch, Mystic Rune Pouch) and the equip hint. Terminology matches the existing use of "Runa" across the series.
